### PR TITLE
chore: rename package and update references to react-native-nitro-apple-sso

### DIFF
--- a/AppleAuth.podspec
+++ b/AppleAuth.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/patrickkabwe/react-native-apple-auth.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/patrickkabwe/react-native-nitro-apple-sso.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# @kazion/react-native-apple-auth
+# react-native-nitro-apple-sso
 
 A React Native module for Apple Sign In Built with Nitro Modules.
 
-[![Build Android](https://github.com/patrickkabwe/react-native-apple-auth/actions/workflows/android-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-apple-auth/actions/workflows/android-build.yml)
-[![Build iOS](https://github.com/patrickkabwe/react-native-apple-auth/actions/workflows/ios-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-apple-auth/actions/workflows/ios-build.yml)
-[![npm version](https://img.shields.io/npm/v/@kazion/react-native-apple-auth.svg?style=flat-square)](https://www.npmjs.com/package/@kazion/react-native-apple-auth)
-[![npm downloads](https://img.shields.io/npm/dm/@kazion/react-native-apple-auth.svg?style=flat-square)](https://www.npmjs.com/package/@kazion/react-native-apple-auth)
+[![Build Android](https://github.com/patrickkabwe/react-native-nitro-apple-sso/actions/workflows/android-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-nitro-apple-sso/actions/workflows/android-build.yml)
+[![Build iOS](https://github.com/patrickkabwe/react-native-nitro-apple-sso/actions/workflows/ios-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-nitro-apple-sso/actions/workflows/ios-build.yml)
+[![npm version](https://img.shields.io/npm/v/react-native-nitro-apple-sso.svg?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-apple-sso)
+[![npm downloads](https://img.shields.io/npm/dm/react-native-nitro-apple-sso.svg?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-apple-sso)
 
 ## Features
 
@@ -24,7 +24,7 @@ A React Native module for Apple Sign In Built with Nitro Modules.
 ## Installation
 
 ```bash
-bun add @kazion/react-native-apple-auth react-native-nitro-modules
+bun add react-native-nitro-apple-sso react-native-nitro-modules
 
 # Install iOS dependencies
 cd ios && pod install && cd ..
@@ -39,7 +39,7 @@ import {
     AppleAuthCredential,
     AppleAuthScopes,
     RNAppleAuth,
-} from "@kazion/react-native-apple-auth";
+} from "react-native-nitro-apple-sso";
 import { useState } from "react";
 import { Button, SafeAreaView, Text, View } from "react-native";
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import {
   AppleAuth,
   AppleAuthCredential,
   AppleAuthScopes,
-} from '@kazion/react-native-apple-auth';
+} from 'react-native-nitro-apple-sso';
 import React, {useState} from 'react';
 import {Button, SafeAreaView, Text} from 'react-native';
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,10 +1,10 @@
+import React, { useState } from 'react';
+import { Button, SafeAreaView, Text } from 'react-native';
 import {
-  AppleAuth,
   AppleAuthCredential,
   AppleAuthScopes,
+  AppleSSO,
 } from 'react-native-nitro-apple-sso';
-import React, {useState} from 'react';
-import {Button, SafeAreaView, Text} from 'react-native';
 
 const App = () => {
   const [loading, setLoading] = useState(false);
@@ -15,7 +15,7 @@ const App = () => {
   const handleAppleSignin = async () => {
     setLoading(true);
     try {
-      const appleAuthCredential = await AppleAuth.signIn({
+      const appleAuthCredential = await AppleSSO.signIn({
         scopes: [AppleAuthScopes.EMAIL, AppleAuthScopes.FULL_NAME],
       });
       setCredentials(appleAuthCredential);
@@ -27,7 +27,7 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={{flex: 1}}>
+    <SafeAreaView style={{ flex: 1 }}>
       <Text>Apple Auth With Nitro Modules</Text>
       <Text>Email: {credentials?.email ?? 'No Email'}</Text>
       <Text>Full Name: {credentials?.fullName ?? 'No Full Name'}</Text>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AppleAuth (0.2.1):
+  - AppleAuth (0.3.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1936,7 +1936,7 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AppleAuth: 16f062f321b2dbf0aac5061a2b58b5a257002d6a
+  AppleAuth: 16ebd61c20132972a753628138853519897c9f38
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@kazion/react-native-apple-auth": ["../src"]
+      "react-native-nitro-apple-sso": ["../src"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@kazion/react-native-apple-auth",
+    "name": "react-native-nitro-apple-sso",
     "version": "0.3.0",
     "description": "A React Native module for Apple Sign In Built with Nitro Modules.",
     "main": "./lib/commonjs/index.js",
@@ -16,6 +16,7 @@
     },
     "keywords": [
         "react-native-apple-auth",
+        "react-native-nitro-apple-sso",
         "react-native",
         "apple-auth",
         "apple-sign-in",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ import { NitroModules } from 'react-native-nitro-modules'
 import type { AppleAuth as AppleAuthSpec } from './specs/apple-auth.nitro'
 export * from './types'
 
-export const AppleAuth =
+export const AppleSSO =
     NitroModules.createHybridObject<AppleAuthSpec>('AppleAuth')


### PR DESCRIPTION
- Changed package name from @kazion/react-native-apple-auth to react-native-nitro-apple-sso in package.json, README.md, and example files.
- Updated source URL in AppleAuth.podspec to reflect the new repository.
- Adjusted import statements in example files to use the new package name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated all references to the package name and repository from "@kazion/react-native-apple-auth" to "react-native-nitro-apple-sso" across documentation, configuration files, and import statements.
	- Adjusted installation instructions, import examples, and badges to reflect the new package identity.
	- Renamed exported module and related identifiers from AppleAuth to AppleSSO for consistency with rebranding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->