### PR TITLE
refactor: update README.md to reflect AppleSSO usage in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd ios && pod install && cd ..
 import {
     AppleAuthCredential,
     AppleAuthScopes,
-    RNAppleAuth,
+    AppleSSO,
 } from "react-native-nitro-apple-sso";
 import { useState } from "react";
 import { Button, SafeAreaView, Text, View } from "react-native";
@@ -50,7 +50,7 @@ const App = () => {
     const handleAppleSignIn = async () => {
         setLoading(true);
         try {
-            const appleAuthCredential = await RNAppleAuth.signIn({
+            const appleAuthCredential = await AppleSSO.signIn({
                 scopes: [AppleAuthScopes.EMAIL, AppleAuthScopes.FULL_NAME],
             });
             setCreds(appleAuthCredential);
@@ -157,7 +157,7 @@ Initiates Apple Sign In flow with the specified options.
 **Example:**
 
 ```tsx
-const credential = await RNAppleAuth.signIn({
+    const credential = await AppleSSO.signIn({
     scopes: [AppleAuthScopes.EMAIL, AppleAuthScopes.FULL_NAME],
     operation: AppleAuthOperation.LOGIN,
 });


### PR DESCRIPTION
- Replaced instances of RNAppleAuth with AppleSSO in the README.md file.
- Updated example code to demonstrate the new sign-in method using AppleSSO for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to replace all references of `RNAppleAuth` with `AppleSSO` in import statements, usage examples, and API references. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->